### PR TITLE
Preload redactor

### DIFF
--- a/redactorextras/redactorExtrasPlugin.php
+++ b/redactorextras/redactorExtrasPlugin.php
@@ -65,6 +65,9 @@ class redactorExtrasPlugin extends BasePlugin
 	{
 		if (craft()->request->isCpRequest())
 		{
+	    // Preload redactor. This will prevent race condition errors when using first-party plugins like inlinestyles
+	    craft()->templates->includeJsResource('lib/redactor/redactor.js');
+	    
             // Get settings
             $settings = $this->getSettings();
 


### PR DESCRIPTION
By preloading redactor, we ensure that redactor is loaded on the page before trying to use any first party plugins. Should fix https://github.com/elliotlewis/Redactor-Extras/issues/1
