### PR TITLE
added text-left for alignment

### DIFF
--- a/redactorextras/resources/plugins/alignment.js
+++ b/redactorextras/resources/plugins/alignment.js
@@ -36,6 +36,7 @@ RedactorPlugins.alignment = function()
         {
             this.buffer.set();
             this.alignment.removeAlign();
+            this.block.addClass('text-left');
         },
         setCenter: function()
         {


### PR DESCRIPTION
If element to be aligned is contained in element with text-alignment already set to anything other than left, then this would previously do nothing. Adding the "text-left" class fixes this.